### PR TITLE
Add jobs filtered views 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [Unreleased]
+## [Unreleased]
+
+### Added 
+
+- Jobs filtered views ([#5](https://github.com/virolea/panoptic/pull/5))
 
 ### Changed
 

--- a/app/controllers/panoptic/application_controller.rb
+++ b/app/controllers/panoptic/application_controller.rb
@@ -1,4 +1,5 @@
 module Panoptic
   class ApplicationController < ActionController::Base
+    include Pagy::Backend
   end
 end

--- a/app/controllers/panoptic/jobs/failed_controller.rb
+++ b/app/controllers/panoptic/jobs/failed_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Panoptic
+  class Jobs::FailedController < ApplicationController
+    def index
+      # TODO: use the `failed` scope available in SolidQueue next release
+      @pagy, @jobs = pagy(
+        SolidQueue::Job.joins(:failed_execution).order(created_at: :asc)
+      )
+
+      render "panoptic/jobs/index"
+    end
+  end
+end

--- a/app/controllers/panoptic/jobs/scheduled_controller.rb
+++ b/app/controllers/panoptic/jobs/scheduled_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Panoptic
+  class Jobs::ScheduledController < ApplicationController
+    def index
+      # TODO: use the `scheduled` scope available in SolidQueue next release
+      @pagy, @jobs = pagy(
+        SolidQueue::Job.joins(:scheduled_execution).order(created_at: :asc)
+      )
+
+      render "panoptic/jobs/index"
+    end
+  end
+end

--- a/app/controllers/panoptic/jobs_controller.rb
+++ b/app/controllers/panoptic/jobs_controller.rb
@@ -2,8 +2,6 @@
 
 module Panoptic
   class JobsController < ApplicationController
-    include Pagy::Backend
-
     def index
       @pagy, @jobs = pagy(SolidQueue::Job.order(created_at: :asc))
     end

--- a/app/views/panoptic/jobs/index.html.erb
+++ b/app/views/panoptic/jobs/index.html.erb
@@ -5,6 +5,9 @@
     <%= link_to "All", jobs_path, class: class_names("nav-link", "active": current_page?(jobs_path)) %>
   </li>
   <li class="nav-item">
+    <%= link_to "Scheduled", scheduled_jobs_path, class: class_names("nav-link", "active": current_page?(scheduled_jobs_path)) %>
+  </li>
+  <li class="nav-item">
     <%= link_to "Failed", failed_jobs_path, class: class_names("nav-link", "active": current_page?(failed_jobs_path)) %>
   </li>
 </ul>

--- a/app/views/panoptic/jobs/index.html.erb
+++ b/app/views/panoptic/jobs/index.html.erb
@@ -1,5 +1,14 @@
 <h1>Jobs</h1>
 
+<ul class="nav nav-underline">
+  <li class="nav-item">
+    <%= link_to "All", jobs_path, class: class_names("nav-link", "active": current_page?(jobs_path)) %>
+  </li>
+  <li class="nav-item">
+    <%= link_to "Failed", failed_jobs_path, class: class_names("nav-link", "active": current_page?(failed_jobs_path)) %>
+  </li>
+</ul>
+
 <div class="d-flex justify-content-end">
   <%== pagy_info(@pagy)  %> 
 </div>
@@ -16,7 +25,7 @@
   </thead>
 
   <tbody>
-    <%= render partial: "job", collection: @jobs %>  
+    <%= render partial: "panoptic/jobs/job", collection: @jobs %>  
   </tbody>
 </table>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,13 @@ Panoptic::Engine.routes.draw do
   root to: "processes#index"
 
   resources :queues, only: [:index]
-  resources :jobs, only: [:index]
+
+  scope "jobs" do
+    get "all", to: "jobs#index", as: "jobs"
+
+    scope module: "jobs" do
+      resources :scheduled, only: :index, as: :scheduled_jobs
+      resources :failed, only: :index, as: :failed_jobs
+    end
+  end
 end

--- a/test/dummy/app/jobs/failing_job.rb
+++ b/test/dummy/app/jobs/failing_job.rb
@@ -1,0 +1,7 @@
+class FailingJob < ApplicationJob
+  retry_on ZeroDivisionError
+
+  def perform
+    1 / 0
+  end
+end


### PR DESCRIPTION
Closes #1 

![CleanShot 2023-12-30 at 07 49 52@2x](https://github.com/virolea/panoptic/assets/3525369/0eeb7b39-2f3c-4e45-8fbf-9a5ad1fcaa6a)

Adds filtered view for jobs: 
- All: all jobs, independent from their state 
- Scheduled: jobs which have an entry in the `solid_queue_scheduled_executions` table
- Failed hobs: jobs which have an entry in the `solid_queue_failed_executions` table 



