### PR TITLE
Failed jobs detailed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+- Add a detailed view for failed jobs ([#6](https://github.com/virolea/panoptic/pull/6))
+
 ## [0.2.0]
 
 ### Added 

--- a/app/controllers/panoptic/jobs/failed_controller.rb
+++ b/app/controllers/panoptic/jobs/failed_controller.rb
@@ -2,12 +2,16 @@
 
 module Panoptic
   class Jobs::FailedController < ApplicationController
-    layout "panoptic/jobs"
+    layout "panoptic/jobs", only: :index
 
     def index
       @pagy, @jobs = pagy(
         Panoptic::FailedJob.order(created_at: :asc)
       )
+    end
+
+    def show
+      @job = Panoptic::FailedJob.find(params[:id])
     end
   end
 end

--- a/app/controllers/panoptic/jobs/failed_controller.rb
+++ b/app/controllers/panoptic/jobs/failed_controller.rb
@@ -5,12 +5,9 @@ module Panoptic
     layout "panoptic/jobs"
 
     def index
-      # TODO: use the `failed` scope available in SolidQueue next release
       @pagy, @jobs = pagy(
-        SolidQueue::Job.joins(:failed_execution).order(created_at: :asc)
+        Panoptic::FailedJob.order(created_at: :asc)
       )
-
-      render "panoptic/jobs/index"
     end
   end
 end

--- a/app/controllers/panoptic/jobs/failed_controller.rb
+++ b/app/controllers/panoptic/jobs/failed_controller.rb
@@ -2,6 +2,8 @@
 
 module Panoptic
   class Jobs::FailedController < ApplicationController
+    layout "panoptic/jobs"
+
     def index
       # TODO: use the `failed` scope available in SolidQueue next release
       @pagy, @jobs = pagy(

--- a/app/controllers/panoptic/jobs/scheduled_controller.rb
+++ b/app/controllers/panoptic/jobs/scheduled_controller.rb
@@ -2,6 +2,8 @@
 
 module Panoptic
   class Jobs::ScheduledController < ApplicationController
+    layout "panoptic/jobs"
+
     def index
       # TODO: use the `scheduled` scope available in SolidQueue next release
       @pagy, @jobs = pagy(

--- a/app/helpers/panoptic/application_helper.rb
+++ b/app/helpers/panoptic/application_helper.rb
@@ -1,6 +1,7 @@
 module Panoptic
   module ApplicationHelper
     include Pagy::Frontend
+    include BreadcrumbsHelper
     include DateTimeHelper
   end
 end

--- a/app/helpers/panoptic/breadcrumbs_helper.rb
+++ b/app/helpers/panoptic/breadcrumbs_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Panoptic
+  module BreadcrumbsHelper
+    def breadcrumb_items
+      @breadcrumb_items ||= []
+    end
+
+    def breadcrumbs
+      tag.nav(aria: { label: "breadcrumb" }) do
+        tag.ol(class: "breadcrumb") do
+          breadcrumb_items.map do |item|
+            concat tag.li(item, class: "breadcrumb-item")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/panoptic/failed_job.rb
+++ b/app/models/panoptic/failed_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Panoptic
+  class FailedJob < SolidQueue::Job
+    # TODO: use the `failed` scope available in SolidQueue next release
+    default_scope { joins(:failed_execution) }
+
+    def exception_class
+      failed_execution.error["exception_class"]
+    end
+
+    def enqueued_at
+      Time.parse(arguments["enqueued_at"])
+    end
+  end
+end

--- a/app/models/panoptic/failed_job.rb
+++ b/app/models/panoptic/failed_job.rb
@@ -5,12 +5,20 @@ module Panoptic
     # TODO: use the `failed` scope available in SolidQueue next release
     default_scope { joins(:failed_execution) }
 
+    def enqueued_at
+      Time.parse(arguments["enqueued_at"])
+    end
+
     def exception_class
       failed_execution.error["exception_class"]
     end
 
-    def enqueued_at
-      Time.parse(arguments["enqueued_at"])
+    def exception_message
+      failed_execution.error["message"]
+    end
+
+    def stacktrace
+      failed_execution.error["backtrace"]
     end
   end
 end

--- a/app/views/layouts/panoptic/application.html.erb
+++ b/app/views/layouts/panoptic/application.html.erb
@@ -7,7 +7,7 @@
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
 </head>
-<body>
+<body class="pb-4">
   <%= render "shared/navbar" %>
 
   <main class="container mt-2">

--- a/app/views/layouts/panoptic/application.html.erb
+++ b/app/views/layouts/panoptic/application.html.erb
@@ -11,7 +11,7 @@
   <%= render "shared/navbar" %>
 
   <main class="container mt-2">
-    <%= yield %>
+    <%= content_for?(:content) ? yield(:content) : yield %>
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>

--- a/app/views/layouts/panoptic/jobs.html.erb
+++ b/app/views/layouts/panoptic/jobs.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:content) do %>
+  <h1>Jobs</h1>
+
+  <ul class="nav nav-underline">
+    <li class="nav-item">
+      <%= link_to "All", jobs_path, class: class_names("nav-link", "active": current_page?(jobs_path)) %>
+    </li>
+    <li class="nav-item">
+      <%= link_to "Scheduled", scheduled_jobs_path, class: class_names("nav-link", "active": current_page?(scheduled_jobs_path)) %>
+    </li>
+    <li class="nav-item">
+      <%= link_to "Failed", failed_jobs_path, class: class_names("nav-link", "active": current_page?(failed_jobs_path)) %>
+    </li>
+  </ul>
+
+  <div class="d-flex justify-content-end">
+    <%== pagy_info(@pagy)  %> 
+  </div>
+  
+  <%= yield %>
+
+  <div class="d-flex justify-content-center">
+    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+  </div>
+<% end %>
+
+<%= render template: "layouts/panoptic/application" %>

--- a/app/views/panoptic/jobs/failed/_job.html.erb
+++ b/app/views/panoptic/jobs/failed/_job.html.erb
@@ -4,4 +4,7 @@
   <td scope="col"><%= job.queue_name %></td>
   <td scope="col" class="font-monospace"><%= job.exception_class %></td>
   <td scope="col"><%= safe_time_tag job.enqueued_at %></td>
+  <td scope="col">
+    <%= link_to "Details", failed_job_path(job) %>
+  </td>
 </tr>

--- a/app/views/panoptic/jobs/failed/_job.html.erb
+++ b/app/views/panoptic/jobs/failed/_job.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <th scope="row"><%= job.id %></th>
+  <td scope="col"><%= job.class_name %></td>
+  <td scope="col"><%= job.queue_name %></td>
+  <td scope="col" class="font-monospace"><%= job.exception_class %></td>
+  <td scope="col"><%= safe_time_tag job.enqueued_at %></td>
+</tr>

--- a/app/views/panoptic/jobs/failed/index.html.erb
+++ b/app/views/panoptic/jobs/failed/index.html.erb
@@ -6,6 +6,7 @@
       <th scope="col">Queue</th>
       <th scope="col">Exception</th>
       <th scope="col">Enqueued</th>
+      <th scope="col"></th>
     </tr>
   </thead>
 

--- a/app/views/panoptic/jobs/failed/index.html.erb
+++ b/app/views/panoptic/jobs/failed/index.html.erb
@@ -1,0 +1,15 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Class</th>
+      <th scope="col">Queue</th>
+      <th scope="col">Exception</th>
+      <th scope="col">Enqueued</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <%= render partial: "job", collection: @jobs %>  
+  </tbody>
+</table>

--- a/app/views/panoptic/jobs/failed/show.html.erb
+++ b/app/views/panoptic/jobs/failed/show.html.erb
@@ -1,0 +1,24 @@
+<% breadcrumb_items.push link_to("Jobs", jobs_path) %>
+<% breadcrumb_items.push link_to("Failed", failed_jobs_path) %>
+<% breadcrumb_items.push @job.id %>
+<%= breadcrumbs %>
+
+<h1><%= @job.class_name %></h1>
+
+<div class="alert alert-danger" role="alert">
+  <h4 class="alert-heading"><%= @job.exception_class %></h4>
+  <p class="font-monospace mb-0">
+    <%= @job.exception_message %>
+  </p>
+</div>
+
+<div class="card" >
+  <div class="card-header">
+    Stacktrace
+  </div>
+  <ul class="list-group list-group-flush font-monospace text-xs">
+    <% @job.stacktrace.each do |trace| %>
+      <li class="list-group-item"><%= trace %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/panoptic/jobs/index.html.erb
+++ b/app/views/panoptic/jobs/index.html.erb
@@ -1,21 +1,3 @@
-<h1>Jobs</h1>
-
-<ul class="nav nav-underline">
-  <li class="nav-item">
-    <%= link_to "All", jobs_path, class: class_names("nav-link", "active": current_page?(jobs_path)) %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Scheduled", scheduled_jobs_path, class: class_names("nav-link", "active": current_page?(scheduled_jobs_path)) %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Failed", failed_jobs_path, class: class_names("nav-link", "active": current_page?(failed_jobs_path)) %>
-  </li>
-</ul>
-
-<div class="d-flex justify-content-end">
-  <%== pagy_info(@pagy)  %> 
-</div>
-
 <table class="table">
   <thead>
     <tr>
@@ -31,7 +13,3 @@
     <%= render partial: "panoptic/jobs/job", collection: @jobs %>  
   </tbody>
 </table>
-
-<div class="d-flex justify-content-center">
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Panoptic::Engine.routes.draw do
 
     scope module: "jobs" do
       resources :scheduled, only: :index, as: :scheduled_jobs
-      resources :failed, only: :index, as: :failed_jobs
+      resources :failed, only: [:index, :show], as: :failed_jobs
     end
   end
 end


### PR DESCRIPTION
Closes #2 

Adds a dedicated `index` and `show` view for failed jobs.

|Index view|Show view|
|---|---|
|![CleanShot 2023-12-30 at 11 21 30@2x](https://github.com/virolea/panoptic/assets/3525369/c0236612-705f-4d20-bde7-4fc780424f1f)|![CleanShot 2023-12-30 at 11 21 35@2x](https://github.com/virolea/panoptic/assets/3525369/dea9958e-aa91-4102-a246-22971b1fd296)|

- The index view features new `Exception` and `Enqueued` information compared to the other jobs view
- The detailed view features the error message as well as a stack trace

