### PR TITLE
Add ability to delete a failed job

### DIFF
--- a/app/controllers/panoptic/jobs/failed_controller.rb
+++ b/app/controllers/panoptic/jobs/failed_controller.rb
@@ -13,5 +13,16 @@ module Panoptic
     def show
       @job = Panoptic::FailedJob.find(params[:id])
     end
+
+    def destroy
+      @job = Panoptic::FailedJob.find(params[:id])
+      if @job.destroy
+        redirect_back fallback_location: failed_jobs_path,
+                      notice: "Job was successfully deleted."
+      else
+        redirect_back fallback_location: failed_jobs_path,
+                      alert: @job.errors.full_messages.to_sentence
+      end
+    end
   end
 end

--- a/app/views/panoptic/jobs/failed/_job.html.erb
+++ b/app/views/panoptic/jobs/failed/_job.html.erb
@@ -9,5 +9,10 @@
     <%= button_to "Retry Job", job_retry_path(job),
           class: "btn btn-link",
           form_class: "d-inline" %>
+    <%= button_to "Delete Job", failed_job_path(job),
+          method: :delete,
+          form: { data: { turbo_confirm: "Are you sure you want delete?" } },
+          class: "btn btn-link text-danger",
+          form_class: "d-inline" %>
   </td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Panoptic::Engine.routes.draw do
 
   scope :jobs, module: :jobs do
     resources :scheduled, only: :index, as: :scheduled_jobs
-    resources :failed, only: [:index, :show], as: :failed_jobs
+    resources :failed, only: [:index, :show, :destroy], as: :failed_jobs
   end
 end


### PR DESCRIPTION
This adds a link button to delete a failed job:
![CleanShot 2024-01-23 at 16 58 34@2x](https://github.com/virolea/panoptic/assets/5077225/b1a32694-6a8c-4186-ab8e-f9e827618417)
![CleanShot 2024-01-23 at 16 58 55@2x](https://github.com/virolea/panoptic/assets/5077225/107247b3-89ad-41f2-8cfc-0923a0deedc9)
![CleanShot 2024-01-23 at 16 58 58@2x](https://github.com/virolea/panoptic/assets/5077225/31533f20-d5e8-4c89-8e08-95c6e3ae15e4)
